### PR TITLE
Add information about libraries needed to compile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To compile this project you only need:
 1. The [cairo development libraries](https://www.cairographics.org/download/) for cairo-sys.
 1. The [libgtk development libraries](https://www.gtk.org/docs/installations/) for pango-sys.
 
-Then you can just `cargo build --release` and the compiled executable should be located in `./target/release/hello-world.rs`.
+Then you can just `cargo build --release` and the compiled executable should be located in `./target/release/hello-world`.
 
 
 ### Why rust(🚀) while its only 1 line and depends on 600 c bind crates?


### PR DESCRIPTION
When I tried to compile this blazingly fast rust (:rocket:) project, both cairo-sys and pango-sys failed with these errors:

```
The following warnings were emitted during compilation:

warning: `"pkg-config" "--libs" "--cflags" "cairo" "cairo >= 1.14"` did not exit successfully: exit status: 1

error: failed to run custom build command for `cairo-sys-rs v0.14.0`

Caused by:
  process didn't exit successfully: `/home/felix/Desktop/hello-world.rs/target/debug/build/cairo-sys-rs-946a4780de3c664c/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=CAIRO_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  cargo:warning=`"pkg-config" "--libs" "--cflags" "cairo" "cairo >= 1.14"` did not exit successfully: exit status: 1
  --- stderr
  Package cairo was not found in the pkg-config search path.
  Perhaps you should add the directory containing `cairo.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'cairo' found
  Package cairo was not found in the pkg-config search path.
  Perhaps you should add the directory containing `cairo.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'cairo' found
```
and
```
The following warnings were emitted during compilation:

warning: `"pkg-config" "--libs" "--cflags" "pango" "pango >= 1.38"` did not exit successfully: exit status: 1

error: failed to run custom build command for `pango-sys v0.14.0`

Caused by:
  process didn't exit successfully: `/home/felix/Desktop/hello-world.rs/target/debug/build/pango-sys-94cd9d99d6151f74/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=PANGO_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  cargo:warning=`"pkg-config" "--libs" "--cflags" "pango" "pango >= 1.38"` did not exit successfully: exit status: 1
  --- stderr
  Package pango was not found in the pkg-config search path.
  Perhaps you should add the directory containing `pango.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'pango' found
  Package pango was not found in the pkg-config search path.
  Perhaps you should add the directory containing `pango.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'pango' found
```

I fixed this issue by installing the dev libraries for both cairo and gtk as stated on the crates.io pages of these crates.

I added the download links to the README.md so nobody else has to fight with these cryptic error messages.