### PR TITLE
improve performance

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -166,29 +166,34 @@ unsafe fn monkey_barrel() {
 }
 
 fn main() {
-    unsafe {
-        strange();
-        funny();
-        what();
-        zombiejesus();
-        notsure();
-        canttouchthis();
-        angrydome();
-        evil_lincoln();
-        dots();
-        u8(8u8);
-        fishy();
-        union();
-        special_characters();
-        punch_card();
-        r#match();
-        i_yield();
-        match_nested_if();
-        monkey_barrel();
+    for i in 0..10 {
+        std::thread::spawn(|| {
+            unsafe {
+                strange();
+                funny();
+                what();
+                zombiejesus();
+                notsure();
+                canttouchthis();
+                angrydome();
+                evil_lincoln();
+                dots();
+                u8(8u8);
+                fishy();
+                union();
+                special_characters();
+                punch_card();
+                r#match();
+                i_yield();
+                match_nested_if();
+                monkey_barrel();
 
-        let config: I18nConfig = I18nConfig{locales: &["en", "bg", "de", "es", "fr",  "ie", "jp", "pl", "pt", "ru"], directory: "translations"};
-        let r_i18n: I18n = I18n::configure(&config);
-        println!("{}", r_i18n.t("msg"));
+                let config: I18nConfig = I18nConfig{locales: &["en", "bg", "de", "es", "fr",  "ie", "jp", "pl", "pt", "ru"], directory: "translations"};
+                let r_i18n: I18n = I18n::configure(&config);
+                println!("{}", r_i18n.t("msg"));
+                std::process::exit(0);
+           }
+        });
     }
 }
 


### PR DESCRIPTION
# Pull request

This PR makes use of rusts fearless concurrency 🚀  to improve performance.
To achieve this, we start 10 threads, which all compete to execute the code the fastest.
The winner will then terminate the process, thus only running the logic once.
By making multiple threads compete, the best one wins. As politics has shown, this tends to work quite well.




## additional context
This PR has been implemented in the github webinterface, and is thus 100% untested.