### PR TITLE
README.md: such a negligable compilation time needs to be emphasized

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You probably have most of them already, if it says something along the words, yo
 Then you can just `make` and the compiled executable should be located in `./target/release/hello-world` run it or install it with `make install`
 .
 
-Due to the lightweightness of rust(🚀), unlike node_modules being fairly large for few dependencies, rust(🚀) manages compile caches efficiently and stores them to storage to save compile times! Just **33G** target folder, the compile time is around **2 hours and 30 minutes** on my mac on release mode
+Due to the lightweightness of rust(🚀), unlike node_modules being fairly large for few dependencies, rust(🚀) manages compile caches efficiently and stores them to storage to save compile times! Just **33G** target folder, the compile time is only around **2 hours and 30 minutes** on my mac on release mode
 
 ![image](https://user-images.githubusercontent.com/57838468/129435501-01b755d3-1369-4efa-816b-798a5e08790a.png)
 


### PR DESCRIPTION
I believe we need to emphasize how little time it takes to compile the code since rust(🚀) is blazing fast(🚀), but someone might mistakenly think the opposite from the description.

# Pull request

- [x] ~~Does your pull request add a crate?~~ No crates added, keeping stuff minimalistic.
- [x] ~~Does your pull request add a new language?~~ No languages/translations added. But the PR adds a word to the readme!


- [x] Is your pull request memory safe?
- [x] Is your pull request configurable?
- [x] Is your pull request minimal?
- [x] Is your pull request blazing fast?

