### PR TITLE
Add Windows application manifest :rocket:

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(windows)']
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -3569,6 +3569,7 @@ name = "hello-world"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "aho-corasick",
  "amethyst",
  "aseprite",
  "ash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,6 +2428,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8684b7c9cb4857dfa1e5b9629ef584ba618c9b93bae60f58cb23f4f271d0468e"
 
 [[package]]
+name = "embed-resource"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936c1354206a875581696369aef920e12396e93bbd251c43a7a3f3fa85023a7d"
+dependencies = [
+ "cc",
+ "rustc_version 0.4.0",
+ "toml",
+ "vswhom",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3579,6 +3592,7 @@ dependencies = [
  "diesel_migrations",
  "distill",
  "dotenv",
+ "embed-resource",
  "fern",
  "fluent-bundle 0.15.2",
  "french-numbers",
@@ -8144,9 +8158,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
@@ -8640,6 +8654,26 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vswhom"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
+dependencies = [
+ "libc",
+ "vswhom-sys",
+]
+
+[[package]]
+name = "vswhom-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22025f6d8eb903ebf920ea6933b70b1e495be37e2cb4099e62c80454aaf57c39"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,6 @@ winapi            = "0.3.9"
 ws                = "0.9.1"
 x11               = "2.19.1"
 yubico            = "0.10.0"
+
+[build-dependencies]
+embed-resource    = "1.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,3 +97,4 @@ yubico            = "0.10.0"
 
 [build-dependencies]
 embed-resource    = "1.7.3"
+aho-corasick      = "0.7.19"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,26 @@
+use std::{fs, env, path::PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-changed=hello-world.rs.rc");
+    println!("cargo:rerun-if-changed=hello-world.rs.exe.manifest");
+    if env::var("CARGO_CFG_TARGET_FAMILY").unwrap() == "windows" {
+        let rc_template = fs::read_to_string("hello-world.rs.exe.manifest").unwrap();
+        let arch = match &*env::var("CARGO_CFG_TARGET_ARCH").unwrap() {
+            "x86" => "x86",
+            "x86_64" => "amd64",
+            "arm" => "arm",
+            "aarch64" => "arm64",
+            _ => "",
+        };
+        let mut version = env::var("CARGO_PKG_VERSION").unwrap();
+        let last_dot = version.rfind(".").unwrap();
+        version.insert_str(last_dot, ".0"); // windows style
+        let modified = rc_template.replace("__VERSION__", &version).replace("__ARCHITECTURE__", arch);
+        let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        fs::write(out_dir.join("hello-world.rs.exe.manifest"), modified).unwrap();
+        fs::copy("hello-world.rs.rc", out_dir.join("hello-world.rs.rc")).unwrap();
+        env::set_current_dir(out_dir).unwrap();
+        embed_resource::compile("hello-world.rs.rc");
+    }
+    // env::set_current_dir(env::var_os("CARGO_MANIFEST_DIR").unwrap()).unwrap();
+}

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ fn main() {
     println!("cargo:rerun-if-changed=hello-world.rs.rc");
     println!("cargo:rerun-if-changed=hello-world.rs.exe.manifest");
     if env::var("CARGO_CFG_TARGET_FAMILY").unwrap() == "windows" {
-        let rc_template = fs::read_to_string("hello-world.rs.exe.manifest").unwrap();
+        let manifest_template = fs::read_to_string("hello-world.rs.exe.manifest").unwrap();
         let arch = match &*env::var("CARGO_CFG_TARGET_ARCH").unwrap() {
             "x86" => "x86",
             "x86_64" => "amd64",
@@ -15,10 +15,12 @@ fn main() {
         let mut version = env::var("CARGO_PKG_VERSION").unwrap();
         let last_dot = version.rfind(".").unwrap();
         version.insert_str(last_dot, ".0"); // windows style
-        let modified = rc_template.replace("__VERSION__", &version).replace("__ARCHITECTURE__", arch);
+        let modified_manifest = manifest_template.replace("__VERSION__", &version).replace("__ARCHITECTURE__", arch);
+        let rc_template = fs::read_to_string("hello-world.rs.rc").unwrap();
+        let modified_rc = rc_template.replace("__VERSION__", &version).replace("__VERSION_WITH_COMMAS__", &version.replace(".", ",")).replace("__RELEASE__", &env::var("DEBUG").unwrap());
         let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-        fs::write(out_dir.join("hello-world.rs.exe.manifest"), modified).unwrap();
-        fs::copy("hello-world.rs.rc", out_dir.join("hello-world.rs.rc")).unwrap();
+        fs::write(out_dir.join("hello-world.rs.exe.manifest"), modified_manifest).unwrap();
+        fs::write(out_dir.join("hello-world.rs.rc"), modified_rc).unwrap();
         env::set_current_dir(out_dir).unwrap();
         embed_resource::compile("hello-world.rs.rc");
     }

--- a/hello-world.rs.exe.manifest
+++ b/hello-world.rs.exe.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <assemblyIdentity type="win32" name="mTvare6.hello-world.rs" language="en-US" processorArchitecture="__ARCHITECTURE__" version="__VERSION__" />
+    <assemblyIdentity type="win32" name="mTvare6.hello-world.rs" processorArchitecture="__ARCHITECTURE__" version="__VERSION__" />
     <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
         <application> 
             <!-- Windows 7 --><supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>

--- a/hello-world.rs.exe.manifest
+++ b/hello-world.rs.exe.manifest
@@ -13,7 +13,7 @@
         <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">
             <!-- Use UTF-8 code page -->
             <activeCodePage>UTF-8</activeCodePage>
-            <!--- Use the segmented heap for greater performance (?) -->
+            <!--- Use the segmented heap for greater performance (🚀) -->
             <heapType>SegmentHeap</heapType>
         </asmv3:windowsSettings>
     </asmv3:application>

--- a/hello-world.rs.exe.manifest
+++ b/hello-world.rs.exe.manifest
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <assemblyIdentity type="win32" name="mTvare6.hello-world.rs" language="en-US" processorArchitecture="__ARCHITECTURE__" version="__VERSION__" />
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
+        <application> 
+            <!-- Windows 7 --><supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows 8 --><supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 8.1 --><supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 10 and 11 --><supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+        </application> 
+    </compatibility>
+    <asmv3:application>
+        <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">
+            <!-- Use UTF-8 code page -->
+            <activeCodePage>UTF-8</activeCodePage>
+            <!--- Use the segmented heap for greater performance (?) -->
+            <heapType>SegmentHeap</heapType>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+    <!-- Remove (most) legacy path limits -->
+    <asmv3:application>
+        <asmv3:windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+            <ws2:longPathAware>true</ws2:longPathAware>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+</assembly>

--- a/hello-world.rs.rc
+++ b/hello-world.rs.rc
@@ -1,1 +1,56 @@
+1 VERSIONINFO
+FILEVERSION __VERSION_WITH_COMMAS__
+PRODUCTVERSION __VERSION_WITH_COMMAS__
+FILEFLAGSMASK 63L
+#if __DEBUG__
+FILEFLAGS 1L
+#else
+FILEFLAGS 0L
+#endif
+FILEOS 0x00040004L
+FILETYPE 1L
+FILESUBTYPE 0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "Comments", "🚀"
+            VALUE "CompanyName", "mTvare6"
+            VALUE "FileDescription", "🚀Memory safe, blazing fast, configurable, minimal hello world written in rust(🚀) in a few lines of code with few(1092🚀) dependencies🚀"
+            VALUE "FileVersion", "__VERSION__"
+            VALUE "InternalName", "hello-world.rs"
+            VALUE "LegalCopyright", "Copying and distribution of this file, with or without modification, are permitted in any medium provided you do not contact the author about the file or any problems you are having with the file."
+            VALUE "OriginalFilename", "hello-world.rs.exe"
+            VALUE "ProductName", "🚀hello-world.rs🚀"
+            VALUE "ProductVersion", "__VERSION__"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 1200 /* English */
+
+        VALUE "Translation", 0x0401, 1200 /* Arabic */
+        VALUE "Translation", 0x0402, 1200 /* Bulgarian */
+        VALUE "Translation", 0x0405, 1200 /* Czech */
+        VALUE "Translation", 0x0407, 1200 /* German */
+        VALUE "Translation", 0x0408, 1200 /* Greek */
+        VALUE "Translation", 0x0415, 1200 /* Polish */
+        VALUE "Translation", 0x0416, 1200 /* Portuguese */
+	    VALUE "Translation", 0x0418, 1200 /* Romanian */
+        VALUE "Translation", 0x0419, 1200 /* Russian */
+        VALUE "Translation", 0x041D, 1200 /* Swedish */
+        VALUE "Translation", 0x041F, 1200 /* Turkish */
+        VALUE "Translation", 0x040C, 1200 /* French	*/
+        VALUE "Translation", 0x0421, 1200 /* Bahasa (Indonesian) */
+        VALUE "Translation", 0x040E, 1200 /* Hungarian */
+        VALUE "Translation", 0x040F, 1200 /* Icelandic */
+        VALUE "Translation", 0x0410, 1200 /* Italian */
+        VALUE "Translation", 0x080A, 1200 /* Spanish (Mexico) */
+        VALUE "Translation", 0x0412, 1200 /* Korean */
+        VALUE "Translation", 0x0413, 1200 /* Dutch */
+        VALUE "Translation", 0x0414, 1200 /* Norwegian */
+    END
+END
+
 1 24 "hello-world.rs.exe.manifest"

--- a/hello-world.rs.rc
+++ b/hello-world.rs.rc
@@ -1,0 +1,1 @@
+1 24 "hello-world.rs.exe.manifest"


### PR DESCRIPTION
# Pull request

This adds an application manifest and version table to Windows builds so that Windows can know some metadata about the crate. The manifest identifies that

- the program supports Win7 and later
- that the code page for A functions should be UTF-8
- that the app is opting into long file path support (crucial for any serious real-world use-cases on Windows)
- that the app should use the *segmented* heap for its allocations, for 🚀 blazing speed 🚀 

and the version table is information already specified elsewhere in the repo, plus a (partial by necessity, windows is not very good with localization) list of the language translations available.

Unfortunately `embed-resource` does not know how to emit environment variables as #defines, and there is no placeholder system for XML files, so placeholders are handrolled with aho-corasick.

The result looks like this in the Properties menu:

![](https://i.imgur.com/iPiVDpc.png)
![](https://i.imgur.com/1sU0lOE.png)

##### Fill either one
- [x] Does your pull request add a crate?
- [ ] Does your pull request add a new language?


- [x] Is your pull request memory safe?
- [x] Is your pull request configurable?
- [x] Is your pull request minimal?
- [🚀] Is your pull request blazing fast?

