### PR TITLE
Fix PKGBUILD and make install (🚀🚀🚀)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean: ./target
 	@rm -rf -- target
  
 install: ./target/release/hello-world
-	@install -Dm755 -- ./target/release/hello-world $(DESTDIR)$(PREFIX)/bin
+	@install -Dm755 -- ./target/release/hello-world $(DESTDIR)$(PREFIX)/bin/hello-world
 
 uninstall: $(DESTDIR)$(PREFIX)/bin/hello-world
 	@rm -- $(DESTDIR)$(PREFIX)/bin/hello-world

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname='hello-world-git'
 _pkgname='hello-world.rs'
-pkgver=0.1.0.r344.e17db4b
+pkgver=0.1.0.r354.75cb3dc
 pkgrel=1
 arch=(x86_64 i686 pentium4 armv6h armv7h aarch64)
 url="https://github.com/mTvare6/hello-world.rs"
@@ -26,7 +26,7 @@ build() {
 package() {
 	cd "$_pkgname"
 	make PREFIX=/usr DESTDIR="${pkgdir}" install
-	install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+	install -Dm644 LICENSE.rs "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 	install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
 }
 # vim:set ts=4 sw=4 noet:


### PR DESCRIPTION
The current Makefile (why are you using build tools written in C(ringe) anyway? :nauseated_face:) will attempt to install the binary to the path "/usr/bin" if it doesn't exist already. It makes sense to not want any non-blazing fast (:rocket:) software on your computer, however pacman (another C(VE) tool :nauseated_face:) complains about "conflicting files". Also the PKGBUILD doesn't have the correct path to the license file after it was rewritten in :rocket::rocket::rocket: memory-safe :rocket::rocket::rocket: blazing-fast :rocket::rocket::rocket: Rust :rocket::rocket::rocket:, which I've also fixed.